### PR TITLE
Add connection QR code and link

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "clipboard-copy": "^4.0.1",
+        "qrcode-svg": "^1.1.0",
         "webnative": "0.33.0-alpha-4"
       },
       "devDependencies": {
@@ -3628,6 +3629,14 @@
       "dev": true,
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/qrcode-svg": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/qrcode-svg/-/qrcode-svg-1.1.0.tgz",
+      "integrity": "sha512-XyQCIXux1zEIA3NPb0AeR8UMYvXZzWEhgdBgBjH9gO7M48H9uoHzviNz8pXw3UzrAcxRRRn9gxHewAVK7bn9qw==",
+      "bin": {
+        "qrcode-svg": "bin/qrcode-svg.js"
       }
     },
     "node_modules/queue-microtask": {
@@ -7390,6 +7399,11 @@
       "version": "2.1.1",
       "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
       "dev": true
+    },
+    "qrcode-svg": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/qrcode-svg/-/qrcode-svg-1.1.0.tgz",
+      "integrity": "sha512-XyQCIXux1zEIA3NPb0AeR8UMYvXZzWEhgdBgBjH9gO7M48H9uoHzviNz8pXw3UzrAcxRRRn9gxHewAVK7bn9qw=="
     },
     "queue-microtask": {
       "version": "1.2.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "svelte-elemetary-template",
       "version": "0.1.0",
       "dependencies": {
+        "clipboard-copy": "^4.0.1",
         "webnative": "0.33.0-alpha-4"
       },
       "devDependencies": {
@@ -1293,6 +1294,25 @@
       "funding": {
         "url": "https://github.com/chalk/strip-ansi?sponsor=1"
       }
+    },
+    "node_modules/clipboard-copy": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/clipboard-copy/-/clipboard-copy-4.0.1.tgz",
+      "integrity": "sha512-wOlqdqziE/NNTUJsfSgXmBMIrYmfd5V0HCGsR8uAKHcg+h9NENWINcfRjtWGU77wDHC8B8ijV4hMTGYbrKovng==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
     },
     "node_modules/cliui": {
       "version": "7.0.4",
@@ -5727,6 +5747,11 @@
           }
         }
       }
+    },
+    "clipboard-copy": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/clipboard-copy/-/clipboard-copy-4.0.1.tgz",
+      "integrity": "sha512-wOlqdqziE/NNTUJsfSgXmBMIrYmfd5V0HCGsR8uAKHcg+h9NENWINcfRjtWGU77wDHC8B8ijV4hMTGYbrKovng=="
     },
     "cliui": {
       "version": "7.0.4",

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     ]
   },
   "dependencies": {
+    "clipboard-copy": "^4.0.1",
     "webnative": "0.33.0-alpha-4"
   }
 }

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
   },
   "dependencies": {
     "clipboard-copy": "^4.0.1",
+    "qrcode-svg": "^1.1.0",
     "webnative": "0.33.0-alpha-4"
   }
 }

--- a/src/components/auth/backup/BackupDevice.svelte
+++ b/src/components/auth/backup/BackupDevice.svelte
@@ -1,17 +1,23 @@
 <script lang="ts">
   import clipboardCopy from 'clipboard-copy'
+  import QRCode from 'qrcode-svg'
   import { createEventDispatcher } from 'svelte'
 
-  import { sessionStore } from '../../../stores'
+  import { sessionStore, theme } from '../../../stores'
   import type { BackupView } from '$lib/views'
   import ClipboardIcon from '$components/icons/ClipboardIcon.svelte'
 
   const dispatch = createEventDispatcher()
 
-  const copyLink = async () => {
-    const origin = window.location.origin
-    const connectionLink = `${origin}/link?username=${$sessionStore.username}`
+  const origin = window.location.origin
+  const connectionLink = `${origin}/link?username=${$sessionStore.username}`
+  const qrcode = new QRCode({
+    content: connectionLink,
+    color: $theme === 'light' ? '#334155' : '#E2E8F0',
+    background: '#ffffff00'
+  }).svg()
 
+  const copyLink = async () => {
     await clipboardCopy(connectionLink)
   }
 
@@ -24,15 +30,11 @@
 <div class="modal">
   <div class="modal-box w-80 relative text-center">
     <div>
-      <h3 class="mb-7 text-xl font-serif">Connect a backup device</h3>
-
-      <!-- GIANT QR CODE GOES HERE -->
-      QR Codes
-
-      <p class="mt-8 mb-4">
+      <h3 class="pb-1 text-xl font-serif">Connect a backup device</h3>
+      {@html qrcode}
+      <p class="font-extralight pt-1 mb-8">
         Scan this code on the new device, or share the connection link.
       </p>
-
       <button class="btn btn-primary btn-outline" on:click={copyLink}>
         <ClipboardIcon />
         <span class="ml-2">Copy connection link</span>

--- a/src/components/auth/backup/BackupDevice.svelte
+++ b/src/components/auth/backup/BackupDevice.svelte
@@ -1,10 +1,19 @@
 <script lang="ts">
+  import clipboardCopy from 'clipboard-copy'
   import { createEventDispatcher } from 'svelte'
 
+  import { sessionStore } from '../../../stores'
   import type { BackupView } from '$lib/views'
   import ClipboardIcon from '$components/icons/ClipboardIcon.svelte'
 
   const dispatch = createEventDispatcher()
+
+  const copyLink = async () => {
+    const origin = window.location.origin
+    const connectionLink = `${origin}/link?username=${$sessionStore.username}`
+
+    await clipboardCopy(connectionLink)
+  }
 
   const navigate = (view: BackupView) => {
     dispatch('navigate', { view })
@@ -24,7 +33,7 @@
         Scan this code on the new device, or share the connection link.
       </p>
 
-      <button class="btn btn-primary btn-outline" href="/backup">
+      <button class="btn btn-primary btn-outline" on:click={copyLink}>
         <ClipboardIcon />
         <span class="ml-2">Copy connection link</span>
       </button>


### PR DESCRIPTION
## Summary

This PR implements the following **features**

* [x] Add QR code to connect a backup device
* [x] Add copy to clipboard to copy link

This PR implements two options for users to load the app on another device and link their account. A QR code is displayed for devices that can scan them and a direct link is provided for other devices.

Both resolve the current origin + the `link` route with a `username` querystring param. For example, `http://localhost:5173/link?username=sgins87`.