### PR TITLE
Feat: add PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,22 @@
+# Description
+
+Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
+
+## Link to issue
+
+Please add a link to any relevant issues/tickets
+
+## Type of change
+
+Please delete options that are not relevant.
+
+- [ ] Bug fix (non-breaking change that fixes an issue)
+- [ ] New feature (non-breaking change that adds functionality)
+- [ ] Refactor (non-breaking change that updates existing functionality)
+- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
+- [ ] This change requires a documentation update
+- [ ] Comments have been added/updated
+
+## Screenshots/Screencaps
+
+Please add previews of any UI Changes


### PR DESCRIPTION
# Description

Adding a PR template to this repo to: 
A) make it easier for developers to talk/think through the code they've written and 
B) make it easier for PR reviewers to get a sense of how the PR is intended to function

## Link to issue

N/A

## Type of change

- [x] New feature (non-breaking change that adds functionality)

## Screenshots/Screencaps

**Default PR Template View:**
<img width="1077" alt="image" src="https://user-images.githubusercontent.com/1179291/183725600-07fb56c8-4a8d-4b79-b45b-6e26991f5395.png">

