### PR TITLE
Wait for data root before loading filesystem

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "clipboard-copy": "^4.0.1",
         "qrcode-svg": "^1.1.0",
-        "webnative": "0.34.0"
+        "webnative": "0.34.1"
       },
       "devDependencies": {
         "@sveltejs/adapter-static": "1.0.0-next.36",
@@ -5501,9 +5501,9 @@
       }
     },
     "node_modules/webnative": {
-      "version": "0.34.0",
-      "resolved": "https://registry.npmjs.org/webnative/-/webnative-0.34.0.tgz",
-      "integrity": "sha512-BS5pgHx9+sIzZ3NYA9Q76QQOctHFuyZ9p/LC4U4+gWTjycj0efWl0Z2jlsaUyGfqBkFLReyDeTb3ldHkD2PgbA==",
+      "version": "0.34.1",
+      "resolved": "https://registry.npmjs.org/webnative/-/webnative-0.34.1.tgz",
+      "integrity": "sha512-FCY00dBUUHWEdabkLV3INTxnkNVlRQfmiNfe4M+Pg85rppLTHP0WU/MAbPHan5NMdH2j09KPeFmxLD2qbqszHQ==",
       "dependencies": {
         "@ipld/dag-cbor": "^7.0.2",
         "@ipld/dag-pb": "^2.1.17",
@@ -9506,9 +9506,9 @@
       "peer": true
     },
     "webnative": {
-      "version": "0.34.0",
-      "resolved": "https://registry.npmjs.org/webnative/-/webnative-0.34.0.tgz",
-      "integrity": "sha512-BS5pgHx9+sIzZ3NYA9Q76QQOctHFuyZ9p/LC4U4+gWTjycj0efWl0Z2jlsaUyGfqBkFLReyDeTb3ldHkD2PgbA==",
+      "version": "0.34.1",
+      "resolved": "https://registry.npmjs.org/webnative/-/webnative-0.34.1.tgz",
+      "integrity": "sha512-FCY00dBUUHWEdabkLV3INTxnkNVlRQfmiNfe4M+Pg85rppLTHP0WU/MAbPHan5NMdH2j09KPeFmxLD2qbqszHQ==",
       "requires": {
         "@ipld/dag-cbor": "^7.0.2",
         "@ipld/dag-pb": "^2.1.17",

--- a/package.json
+++ b/package.json
@@ -53,6 +53,6 @@
   "dependencies": {
     "clipboard-copy": "^4.0.1",
     "qrcode-svg": "^1.1.0",
-    "webnative": "0.34.0"
+    "webnative": "0.34.1"
   }
 }

--- a/src/components/auth/link/LinkDevice.svelte
+++ b/src/components/auth/link/LinkDevice.svelte
@@ -2,9 +2,10 @@
   import { goto } from '$app/navigation'
   import { page } from '$app/stores'
 
-  import { appName } from '$lib/app-name'
   import { createAccountLinkingConsumer } from '$lib/auth/linking'
   import { loadAccount } from '$lib/common/webnative'
+
+  let loadingFilesystem = false
 
   let displayPin: string = ''
   let url = $page.url
@@ -23,6 +24,8 @@
 
     accountLinkingConsumer.on('link', async ({ approved, username }) => {
       if (approved) {
+        loadingFilesystem = true
+
         await loadAccount(username)
         goto('/')
         // Send up a toast on '/'
@@ -34,35 +37,54 @@
 </script>
 
 <input type="checkbox" id="my-modal-5" checked class="modal-toggle" />
-<div class="modal">
-  <div
-    class="modal-box w-80 relative text-center dark:border-slate-600 dark:border"
-  >
-    <div class="grid grid-flow-row auto-rows-max gap-7">
-      <h3 class="text-xl font-serif">Connection Requested</h3>
-      <div class="grid grid-flow-row auto-rows-max gap-4 justify-items-center">
-        {#if displayPin}
-          <span
-            class="btn btn-info btn-lg rounded-full text-2xl tracking-widest w-3/4 cursor-default"
-          >
-            {displayPin}
-          </span>
-        {/if}
-        <span class="text-md">Enter this code on your connected device.</span>
+{#if loadingFilesystem}
+  <div class="modal">
+    <div
+      class="modal-box rounded-lg shadow-sm bg-slate-100 w-80 relative text-center dark:bg-slate-900 dark:border-slate-600 dark:border "
+    >
+      <p class="text-slate-500 dark:text-slate-50">
+        <span
+          class="rounded-lg border-t-2 border-l-2 border-slate-500 dark:border-slate-50 w-4 h-4 inline-block animate-spin mr-1"
+        />
+        Loading file system...
+      </p>
+    </div>
+  </div>
+{:else}
+  <div class="modal">
+    <div
+      class="modal-box w-80 relative text-center dark:border-slate-600 dark:border"
+    >
+      <div class="grid grid-flow-row auto-rows-max gap-7">
+        <h3 class="text-xl font-serif">Connection Requested</h3>
         <div
-          class="grid grid-flow-col auto-cols-max gap-4 justify-center items-center text-slate-500"
+          class="grid grid-flow-row auto-rows-max gap-4 justify-items-center"
         >
-          <span
-            class="rounded-lg border-t-2 border-l-2 border-slate-600 dark:border-slate-50 w-4 h-4 block animate-spin"
-          />
-          Waiting for a response...
+          {#if displayPin}
+            <span
+              class="btn btn-info btn-lg rounded-full text-2xl tracking-widest w-3/4 cursor-default"
+            >
+              {displayPin}
+            </span>
+          {/if}
+          <span class="text-md">Enter this code on your connected device.</span>
+          <div
+            class="grid grid-flow-col auto-cols-max gap-4 justify-center items-center text-slate-500"
+          >
+            <span
+              class="rounded-lg border-t-2 border-l-2 border-slate-600 dark:border-slate-50 w-4 h-4 block animate-spin"
+            />
+            Waiting for a response...
+          </div>
         </div>
-      </div>
-      <div>
-        <button class="btn btn-primary btn-outline text-base font-normal mt-4">
-          Cancel Request
-        </button>
+        <div>
+          <button
+            class="btn btn-primary btn-outline text-base font-normal mt-4"
+          >
+            Cancel Request
+          </button>
+        </div>
       </div>
     </div>
   </div>
-</div>
+{/if}

--- a/src/lib/common/webnative.ts
+++ b/src/lib/common/webnative.ts
@@ -106,6 +106,8 @@ export const register = async (username: string): Promise<boolean> => {
 }
 
 export const loadAccount = async (username: string): Promise<void> => {
+  await checkDataRoot(username)
+
   const fs = await webnative.loadRootFileSystem()
   filesystemStore.set(fs)
 
@@ -114,4 +116,29 @@ export const loadAccount = async (username: string): Promise<void> => {
     username,
     authed: true
   }))
+}
+
+const checkDataRoot = async (username: string): Promise<void> => {
+  let dataRoot = await webnative.dataRoot.lookup(username)
+
+  if (dataRoot) return
+
+  return new Promise((resolve) => {
+    const maxRetries = 20
+    let attempt = 0
+
+    const dataRootInterval = setInterval(async () => {
+      console.warn('Could not fetch filesystem data root. Retrying.')
+
+      dataRoot = await webnative.dataRoot.lookup(username)
+
+      if (!dataRoot && attempt < maxRetries) {
+        attempt++
+        return
+      }
+
+      clearInterval(dataRootInterval)
+      resolve()
+    }, 500)
+  })
 }


### PR DESCRIPTION
# Description

This PR implements the following features:

- Adds a `checkDataRoot` function that checks for a filesystem data root
- Adds a loading filesystem modal
- Upgrades webnative to 0.34.1

The `checkDataRoot` function prevents a newly linked device from attempting to load a filesystem whose data root is not yet available on DNS.

While waiting for the data root and loading the filesystem, the newly linked device displays the loading filesystem modal.

## Link to issue

Implements #2 

## Type of change

- [x] New feature (non-breaking change that adds functionality)

