### PR TITLE
Add class strategy for selecting dark theme

### DIFF
--- a/tailwind.config.cjs
+++ b/tailwind.config.cjs
@@ -2,6 +2,7 @@ module.exports = {
   mode: "jit",
   content: ["./src/**/*.{html,js,svelte,ts}"],
   plugins: [require("daisyui")],
+  darkMode: ['class', '[data-theme="dark"]'],
   daisyui: {
     styled: true,
     themes: [


### PR DESCRIPTION
# Description

This PR updates the theme application strategy. 

In the previous implementation, `dark` class variants were applied whenever the user `prefers-color-scheme` dark based on their OS preferences. So the dark class variants would be applied even when the user had manually set the theme to light.

The change in this PR sets the dark class variants based on the manually selected theme. We default the theme on first interaction to the OS preference, which means the dark styles will be correctly applied then as well.

Note that the `dark-theme` part of the fix is because that is the mechanism that daisyUI uses for setting themes.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)

## Screenshots/Screencaps

Dark theme (note the borders)

<img width="533" alt="CleanShot 2022-08-29 at 14 56 58@2x" src="https://user-images.githubusercontent.com/7957636/187306211-971418ce-575d-4337-87d2-13c902d3b4f9.png">


Light theme (no borders)

<img width="521" alt="CleanShot 2022-08-29 at 14 55 11@2x" src="https://user-images.githubusercontent.com/7957636/187306093-ca3eea76-854e-4d98-a30e-8959464e9355.png">