### PR TITLE
Show error in UI when registration fails

### DIFF
--- a/src/components/auth/register/Register.svelte
+++ b/src/components/auth/register/Register.svelte
@@ -33,6 +33,8 @@
     authInProcess = true
 
     registrationSuccess = await register(username)
+
+    if (!registrationSuccess) authInProcess = false
   }
 </script>
 

--- a/src/lib/common/webnative.ts
+++ b/src/lib/common/webnative.ts
@@ -89,6 +89,8 @@ export const isUsernameAvailable = async (
 export const register = async (username: string): Promise<boolean> => {
   const { success } = await webnative.account.register({ username })
 
+  if (!success) return success
+
   const fs = await webnative.bootstrapRootFileSystem()
   filesystemStore.set(fs)
 


### PR DESCRIPTION
# Description

Whenever user registration failed from the server, an error hit the console and the interface hung on loading the filesystem. Now it shows an error message.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)

## Screenshots

![image](https://user-images.githubusercontent.com/27258/187519562-0e5a1914-bed4-4d16-85b8-d10a747c994d.png)
