### PR TITLE
Avivash/add fission server url to app info

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,4 @@ node_modules/
 build/
 
 # macOS
-.DS_Store5
+.DS_Store

--- a/src/components/gallery/imageGallery/ImageModal.svelte
+++ b/src/components/gallery/imageGallery/ImageModal.svelte
@@ -4,6 +4,7 @@
   import { deleteImageFromWNFS } from '$lib/gallery'
   import { galleryStore } from '../../../stores'
   import type { Gallery, Image } from '$lib/gallery'
+  import { fissionServerUrl } from '$lib/app-info'
 
   export let image: Image
   export let isModalOpen: boolean = false
@@ -125,7 +126,7 @@
             </button>
           {/if}
           <img
-            class="block object-cover object-center w-full h-full mb-4"
+            class="block object-cover object-center w-full h-full mb-4 rounded-[1rem]"
             alt={`Image: ${image.name}`}
             src={image.src}
           />
@@ -140,7 +141,7 @@
         </div>
         <div class="flex flex-col items-center justify-center">
           <a
-            href={`https://ipfs.runfission.net/ipfs/${image.cid}/userland`}
+            href={`https://ipfs.${fissionServerUrl}/ipfs/${image.cid}/userland`}
             target="_blank"
             class="underline mb-4 hover:text-slate-500"
           >

--- a/src/lib/app-info.ts
+++ b/src/lib/app-info.ts
@@ -2,3 +2,4 @@ export const appName = 'Awesome Webnative App'
 export const appDescription = 'This is another awesome Webnative app.'
 export const appURL = 'https://webnative.netlify.app'
 export const appImageURL = `${appURL}/preview.png`
+export const fissionServerUrl = 'runfission.com'


### PR DESCRIPTION
# Description

- Adding `fissionServerUrl` to `app-info` and adding it to the `ImageModal`, as per @jessmartin's suggestion 👍🏼 
- Fixing a typo for `.DS_Store` inside `.gitignore`
- Adding the same border radius to the `ImageModal` that I added in `walletauth`

## Link to issue

N/A

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)

## Screenshots/Screencaps

**Modal:**
<img width="1187" alt="image" src="https://user-images.githubusercontent.com/1179291/191834720-e6b7df04-0ac7-45dc-a0cc-23c219e6705d.png">

**Image on IPFS:**
https://ipfs.runfission.com/ipfs/bafybeidieo4533jrbuvzrvwgpxn44sqw4xrj5qa6v42tdbpu7n6t56opsu/userland
<img width="1358" alt="image" src="https://user-images.githubusercontent.com/1179291/191834946-896bf285-e857-43f0-9a1e-ffc3b79d1305.png">
