### PR TITLE
Avivash/ddd gallery

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,10 +98,7 @@ The app template is designed to be easy for you to _make it your own._ Here's ho
 
     If you're not building an image gallery, you don't need the gallery demo code, except perhaps to learn from. To get rid of it, delete:
 
-    - `/src/lib/gallery.svelte`
-    - `/src/routes/gallery.svelte`
-    - `/src/components/gallery`
-    - the `galleryStore` in `/src/stores.ts`
+    - `/src/routes/gallery`
     - the `initializeFilesystem` function in `/src/lib/auth/account.ts` creates directories used by WNFS. Change those to what you need for your app or delete them if you're not using WNFS.
 
 👏 You're ready to start adding custom functionality! 🚀
@@ -109,7 +106,6 @@ The app template is designed to be easy for you to _make it your own._ Here's ho
 Check out the [Webnative Guide](https://guide.fission.codes/developers/webnative) for Webnative questions or [UCAN.xyz](https://ucan.xyz) for UCAN questions.
 
 ## 🧨 Deploy
-
 
 The Webnative App Template is currently deployed as a [Netlify app](https://webnative.netlify.app) and a [Fission app](https://webnative-template.fission.app), but it should be supported on any static hosting platform (Vercel, Cloudflare Pages, etc).
 
@@ -120,9 +116,10 @@ In order to deploy your Webnative application on Netlify:
 1. Create a new Netlify site and connect your app's git repository. (If you don't have your application stored in a git repository, you can upload the output of a [static build](#static-build).)
 2. Netlify takes care of the rest. No Netlify-specific configuration is needed.
 3. There is no step 3.
+
 ### Fission App Hosting
 
-A Webnative application can be published to IPFS with the [Fission CLI](https://guide.fission.codes/developers/cli) or the [Fission GitHub publish action](https://github.com/fission-suite/publish-action). 
+A Webnative application can be published to IPFS with the [Fission CLI](https://guide.fission.codes/developers/cli) or the [Fission GitHub publish action](https://github.com/fission-suite/publish-action).
 
 To publish with the Fission CLI:
 

--- a/README.md
+++ b/README.md
@@ -99,7 +99,6 @@ The app template is designed to be easy for you to _make it your own._ Here's ho
     If you're not building an image gallery, you don't need the gallery demo code, except perhaps to learn from. To get rid of it, delete:
 
     - `/src/routes/gallery`
-    - the `initializeFilesystem` function in `/src/lib/auth/account.ts` creates directories used by WNFS. Change those to what you need for your app or delete them if you're not using WNFS.
 
 👏 You're ready to start adding custom functionality! 🚀
 

--- a/src/lib/app-info.ts
+++ b/src/lib/app-info.ts
@@ -2,4 +2,4 @@ export const appName = 'Awesome Webnative App'
 export const appDescription = 'This is another awesome Webnative app.'
 export const appURL = 'https://webnative.netlify.app'
 export const appImageURL = `${appURL}/preview.png`
-export const fissionServerUrl = 'runfission.com'
+export const ipfsGatewayUrl = 'runfission.com'

--- a/src/lib/auth/account.ts
+++ b/src/lib/auth/account.ts
@@ -4,7 +4,8 @@ import type FileSystem from 'webnative/fs/index'
 import { asyncDebounce } from '$lib/utils'
 import { filesystemStore, sessionStore } from '../../stores'
 import { getBackupStatus } from '$lib/auth/backup'
-import { AREAS, GALLERY_DIRS } from '../../routes/gallery/lib/gallery'
+import { AREAS } from '../../routes/gallery/stores'
+import { GALLERY_DIRS } from '../../routes/gallery/lib/gallery'
 
 export const isUsernameValid = async (username: string): Promise<boolean> => {
   return webnative.account.isUsernameValid(username)

--- a/src/lib/auth/account.ts
+++ b/src/lib/auth/account.ts
@@ -4,7 +4,7 @@ import type FileSystem from 'webnative/fs/index'
 import { asyncDebounce } from '$lib/utils'
 import { filesystemStore, sessionStore } from '../../stores'
 import { getBackupStatus } from '$lib/auth/backup'
-import { AREAS, GALLERY_DIRS } from '$lib/gallery'
+import { AREAS, GALLERY_DIRS } from '../../routes/gallery/lib/gallery'
 
 export const isUsernameValid = async (username: string): Promise<boolean> => {
   return webnative.account.isUsernameValid(username)

--- a/src/lib/auth/account.ts
+++ b/src/lib/auth/account.ts
@@ -1,11 +1,8 @@
 import * as webnative from 'webnative'
-import type FileSystem from 'webnative/fs/index'
 
 import { asyncDebounce } from '$lib/utils'
 import { filesystemStore, sessionStore } from '../../stores'
 import { getBackupStatus } from '$lib/auth/backup'
-import { AREAS } from '../../routes/gallery/stores'
-import { GALLERY_DIRS } from '../../routes/gallery/lib/gallery'
 
 export const isUsernameValid = async (username: string): Promise<boolean> => {
   return webnative.account.isUsernameValid(username)
@@ -30,9 +27,6 @@ export const register = async (username: string): Promise<boolean> => {
   const fs = await webnative.bootstrapRootFileSystem()
   filesystemStore.set(fs)
 
-  // TODO Remove if only public and private directories are needed
-  await initializeFilesystem(fs)
-
   sessionStore.update(session => ({
     ...session,
     username,
@@ -40,16 +34,6 @@ export const register = async (username: string): Promise<boolean> => {
   }))
 
   return success
-}
-
-/**
- * Create additional directories and files needed by the app
- *
- * @param fs FileSystem
- */
-const initializeFilesystem = async (fs: FileSystem): Promise<void> => {
-  await fs.mkdir(webnative.path.directory(...GALLERY_DIRS[AREAS.PUBLIC]))
-  await fs.mkdir(webnative.path.directory(...GALLERY_DIRS[AREAS.PRIVATE]))
 }
 
 export const loadAccount = async (username: string): Promise<void> => {

--- a/src/routes/gallery/+layout.svelte
+++ b/src/routes/gallery/+layout.svelte
@@ -1,0 +1,47 @@
+<script lang="ts">
+  import { onDestroy } from 'svelte'
+  import * as wn from 'webnative'
+  import type FileSystem from 'webnative/fs/index'
+
+  import { filesystemStore } from '../../stores'
+  import { AREAS } from './stores'
+  import { GALLERY_DIRS } from './lib/gallery'
+
+  let fsCheckCompleted = false
+
+  /**
+   * Create additional directories and files needed by the gallery if they don't exist
+   *
+   * @param fs FileSystem
+   */
+  const initializeFilesystem = async (fs: FileSystem): Promise<void> => {
+    const publicPathExists = await fs.exists(
+      wn.path.file(...GALLERY_DIRS[AREAS.PUBLIC])
+    )
+    const privatePathExists = await fs.exists(
+      wn.path.file(...GALLERY_DIRS[AREAS.PRIVATE])
+    )
+
+    if (!publicPathExists) {
+      await fs.mkdir(wn.path.directory(...GALLERY_DIRS[AREAS.PUBLIC]))
+    }
+
+    if (!privatePathExists) {
+      await fs.mkdir(wn.path.directory(...GALLERY_DIRS[AREAS.PRIVATE]))
+    }
+
+    fsCheckCompleted = true
+  }
+
+  const unsubscribe = filesystemStore.subscribe(async fs => {
+    if (!fsCheckCompleted && !!fs) {
+      await initializeFilesystem(fs)
+    }
+  })
+
+  onDestroy(unsubscribe)
+</script>
+
+{#if fsCheckCompleted}
+  <slot />
+{/if}

--- a/src/routes/gallery/+layout.svelte
+++ b/src/routes/gallery/+layout.svelte
@@ -3,9 +3,9 @@
   import * as wn from 'webnative'
   import type FileSystem from 'webnative/fs/index'
 
-  import { filesystemStore } from '../../stores'
-  import { AREAS } from './stores'
-  import { GALLERY_DIRS } from './lib/gallery'
+  import { filesystemStore } from '$src/stores'
+  import { AREAS } from '$routes/gallery/stores'
+  import { GALLERY_DIRS } from '$routes/gallery/lib/gallery'
 
   let fsCheckCompleted = false
 

--- a/src/routes/gallery/+page.svelte
+++ b/src/routes/gallery/+page.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { onDestroy } from 'svelte'
   import { goto } from '$app/navigation'
+
   import { sessionStore } from '../../stores'
   import { themeStore } from '../../stores'
   import { galleryStore } from './stores'

--- a/src/routes/gallery/+page.svelte
+++ b/src/routes/gallery/+page.svelte
@@ -2,10 +2,10 @@
   import { onDestroy } from 'svelte'
   import { goto } from '$app/navigation'
 
-  import { sessionStore, themeStore } from '../../stores'
-  import { AREAS, galleryStore } from './stores'
-  import Dropzone from './components/upload/Dropzone.svelte'
-  import ImageGallery from './components/imageGallery/ImageGallery.svelte'
+  import { sessionStore, themeStore } from '$src/stores'
+  import { AREAS, galleryStore } from '$routes/gallery/stores'
+  import Dropzone from '$routes/gallery/components/upload/Dropzone.svelte'
+  import ImageGallery from '$routes/gallery/components/imageGallery/ImageGallery.svelte'
 
   /**
    * Tab between the public/private areas and load associated images

--- a/src/routes/gallery/+page.svelte
+++ b/src/routes/gallery/+page.svelte
@@ -3,10 +3,9 @@
   import { goto } from '$app/navigation'
 
   import { sessionStore, themeStore } from '../../stores'
-  import { galleryStore } from './stores'
+  import { AREAS, galleryStore } from './stores'
   import Dropzone from './components/upload/Dropzone.svelte'
   import ImageGallery from './components/imageGallery/ImageGallery.svelte'
-  import { AREAS } from './lib/gallery'
 
   /**
    * Tab between the public/private areas and load associated images

--- a/src/routes/gallery/+page.svelte
+++ b/src/routes/gallery/+page.svelte
@@ -2,8 +2,7 @@
   import { onDestroy } from 'svelte'
   import { goto } from '$app/navigation'
 
-  import { sessionStore } from '../../stores'
-  import { themeStore } from '../../stores'
+  import { sessionStore, themeStore } from '../../stores'
   import { galleryStore } from './stores'
   import Dropzone from './components/upload/Dropzone.svelte'
   import ImageGallery from './components/imageGallery/ImageGallery.svelte'

--- a/src/routes/gallery/+page.svelte
+++ b/src/routes/gallery/+page.svelte
@@ -1,11 +1,12 @@
 <script lang="ts">
-  import { goto } from '$app/navigation'
   import { onDestroy } from 'svelte'
-
-  import { galleryStore, sessionStore, themeStore } from '../../stores'
-  import { AREAS } from '$lib/gallery'
-  import Dropzone from '$components/gallery/upload/Dropzone.svelte'
-  import ImageGallery from '$components/gallery/imageGallery/ImageGallery.svelte'
+  import { goto } from '$app/navigation'
+  import { sessionStore } from '../../stores'
+  import { themeStore } from '../../stores'
+  import { galleryStore } from './stores'
+  import Dropzone from './components/upload/Dropzone.svelte'
+  import ImageGallery from './components/imageGallery/ImageGallery.svelte'
+  import { AREAS } from './lib/gallery'
 
   /**
    * Tab between the public/private areas and load associated images

--- a/src/routes/gallery/components/icons/FileUploadIcon.svelte
+++ b/src/routes/gallery/components/icons/FileUploadIcon.svelte
@@ -1,0 +1,19 @@
+<script lang="ts">
+  export let classes: string = 'mb-3 w-10 h-10'
+</script>
+
+<svg
+  aria-hidden="true"
+  class={classes}
+  fill="none"
+  stroke="currentColor"
+  viewBox="0 0 24 24"
+  xmlns="http://www.w3.org/2000/svg"
+>
+  <path
+    stroke-linecap="round"
+    stroke-linejoin="round"
+    stroke-width="2"
+    d="M7 16a4 4 0 0 1-.88-7.903A5 5 0 1 1 15.9 6h.1a5 5 0 0 1 1 9.9M15 13l-3-3m0 0-3 3m3-3v12"
+  />
+</svg>

--- a/src/routes/gallery/components/imageGallery/ImageCard.svelte
+++ b/src/routes/gallery/components/imageGallery/ImageCard.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import type { Image } from '$lib/gallery'
+  import type { Image } from '../../lib/gallery'
 
   export let image: Image
   export let openModal

--- a/src/routes/gallery/components/imageGallery/ImageCard.svelte
+++ b/src/routes/gallery/components/imageGallery/ImageCard.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import type { Image } from '../../lib/gallery'
+  import type { Image } from '$routes/gallery/lib/gallery'
 
   export let image: Image
   export let openModal

--- a/src/routes/gallery/components/imageGallery/ImageGallery.svelte
+++ b/src/routes/gallery/components/imageGallery/ImageGallery.svelte
@@ -1,9 +1,9 @@
 <script lang="ts">
   import { onDestroy } from 'svelte'
 
-  import { galleryStore } from '../../stores'
+  import { AREAS, galleryStore } from '../../stores'
   import { filesystemStore, sessionStore } from '../../../../stores'
-  import { AREAS, getImagesFromWNFS, type Image } from '../../lib/gallery'
+  import { getImagesFromWNFS, type Image } from '../../lib/gallery'
   import FileUploadCard from '../upload/FileUploadCard.svelte'
   import ImageCard from './ImageCard.svelte'
   import ImageModal from './ImageModal.svelte'

--- a/src/routes/gallery/components/imageGallery/ImageGallery.svelte
+++ b/src/routes/gallery/components/imageGallery/ImageGallery.svelte
@@ -1,12 +1,12 @@
 <script lang="ts">
   import { onDestroy } from 'svelte'
 
-  import { AREAS, galleryStore } from '../../stores'
-  import { filesystemStore, sessionStore } from '../../../../stores'
-  import { getImagesFromWNFS, type Image } from '../../lib/gallery'
-  import FileUploadCard from '../upload/FileUploadCard.svelte'
-  import ImageCard from './ImageCard.svelte'
-  import ImageModal from './ImageModal.svelte'
+  import { filesystemStore, sessionStore } from '$src/stores'
+  import { AREAS, galleryStore } from '$routes/gallery/stores'
+  import { getImagesFromWNFS, type Image } from '$routes/gallery/lib/gallery'
+  import FileUploadCard from '$routes/gallery/components/upload/FileUploadCard.svelte'
+  import ImageCard from '$routes/gallery/components/imageGallery/ImageCard.svelte'
+  import ImageModal from '$routes/gallery/components/imageGallery/ImageModal.svelte'
 
   /**
    * Open the ImageModal and pass it the selected `image` from the gallery

--- a/src/routes/gallery/components/imageGallery/ImageGallery.svelte
+++ b/src/routes/gallery/components/imageGallery/ImageGallery.svelte
@@ -1,15 +1,11 @@
 <script lang="ts">
   import { onDestroy } from 'svelte'
-
-  import { galleryStore } from '../../../stores'
-  import { AREAS, getImagesFromWNFS } from '$lib/gallery'
-  import type { Image } from '$lib/gallery'
-  import FileUploadCard from '$components/gallery/upload/FileUploadCard.svelte'
-  import ImageCard from '$components/gallery/imageGallery/ImageCard.svelte'
-  import ImageModal from '$components/gallery/imageGallery/ImageModal.svelte'
-
-  // Get images from the user's public WNFS
-  getImagesFromWNFS()
+  import { galleryStore } from '../../stores'
+  import { filesystemStore, sessionStore } from '../../../../stores'
+  import { AREAS, getImagesFromWNFS, type Image } from '../../lib/gallery'
+  import FileUploadCard from '../upload/FileUploadCard.svelte'
+  import ImageCard from './ImageCard.svelte'
+  import ImageModal from './ImageModal.svelte'
 
   /**
    * Open the ImageModal and pass it the selected `image` from the gallery
@@ -23,7 +19,7 @@
 
   // If galleryStore.selectedArea changes from private to public, re-run getImagesFromWNFS
   let selectedArea = null
-  const unsubscribe = galleryStore.subscribe(async updatedStore => {
+  const unsubscribeGalleryStore = galleryStore.subscribe(async updatedStore => {
     // Get initial selectedArea
     if (!selectedArea) {
       selectedArea = updatedStore.selectedArea
@@ -35,7 +31,20 @@
     }
   })
 
-  onDestroy(unsubscribe)
+  // Once the user has been authed, fetch the images from their file system
+  let imagesFetched = false
+  const unsubscribeSessionStore = sessionStore.subscribe((newState) => {
+    if (newState.authed && $filesystemStore && !imagesFetched) {
+      imagesFetched = true
+      // Get images from the user's public WNFS
+      getImagesFromWNFS()
+    }
+  })
+
+  onDestroy(() => {
+    unsubscribeGalleryStore()
+    unsubscribeSessionStore()
+  })
 </script>
 
 <section class="overflow-hidden text-gray-700">

--- a/src/routes/gallery/components/imageGallery/ImageGallery.svelte
+++ b/src/routes/gallery/components/imageGallery/ImageGallery.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { onDestroy } from 'svelte'
+
   import { galleryStore } from '../../stores'
   import { filesystemStore, sessionStore } from '../../../../stores'
   import { AREAS, getImagesFromWNFS, type Image } from '../../lib/gallery'

--- a/src/routes/gallery/components/imageGallery/ImageModal.svelte
+++ b/src/routes/gallery/components/imageGallery/ImageModal.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { createEventDispatcher, onDestroy, onMount } from 'svelte'
+
   import { fissionServerUrl } from '$lib/app-info';
   import { galleryStore } from '../../stores'
   import { deleteImageFromWNFS, type Gallery, type Image } from '../../lib/gallery'

--- a/src/routes/gallery/components/imageGallery/ImageModal.svelte
+++ b/src/routes/gallery/components/imageGallery/ImageModal.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { createEventDispatcher, onDestroy, onMount } from 'svelte'
 
-  import { fissionServerUrl } from '$lib/app-info';
+  import { ipfsGatewayUrl } from '$lib/app-info';
   import { galleryStore } from '$routes/gallery/stores'
   import { deleteImageFromWNFS, type Gallery, type Image } from '$routes/gallery/lib/gallery'
 
@@ -140,7 +140,7 @@
         </div>
         <div class="flex flex-col items-center justify-center">
           <a
-            href={`https://ipfs.${fissionServerUrl}/ipfs/${image.cid}/userland`}
+            href={`https://ipfs.${ipfsGatewayUrl}/ipfs/${image.cid}/userland`}
             target="_blank"
             class="underline mb-4 hover:text-slate-500"
           >

--- a/src/routes/gallery/components/imageGallery/ImageModal.svelte
+++ b/src/routes/gallery/components/imageGallery/ImageModal.svelte
@@ -117,7 +117,7 @@
         <div class="relative">
           {#if showPreviousArrow}
             <button
-              class="absolute top-1/2 -left-[21px] -translate-y-1/2 inline-block text-center text-[40px]"
+              class="absolute top-1/2 -left-[25px] -translate-y-1/2 inline-block text-center text-[40px]"
               on:click={() => handleNextOrPrevImage('prev')}
             >
               &#8249;
@@ -130,7 +130,7 @@
           />
           {#if showNextArrow}
             <button
-              class="absolute top-1/2 -right-[21px] -translate-y-1/2 inline-block text-center text-[40px]"
+              class="absolute top-1/2 -right-[25px] -translate-y-1/2 inline-block text-center text-[40px]"
               on:click={() => handleNextOrPrevImage('next')}
             >
               &#8250;

--- a/src/routes/gallery/components/imageGallery/ImageModal.svelte
+++ b/src/routes/gallery/components/imageGallery/ImageModal.svelte
@@ -2,8 +2,8 @@
   import { createEventDispatcher, onDestroy, onMount } from 'svelte'
 
   import { fissionServerUrl } from '$lib/app-info';
-  import { galleryStore } from '../../stores'
-  import { deleteImageFromWNFS, type Gallery, type Image } from '../../lib/gallery'
+  import { galleryStore } from '$routes/gallery/stores'
+  import { deleteImageFromWNFS, type Gallery, type Image } from '$routes/gallery/lib/gallery'
 
   export let image: Image
   export let isModalOpen: boolean = false

--- a/src/routes/gallery/components/imageGallery/ImageModal.svelte
+++ b/src/routes/gallery/components/imageGallery/ImageModal.svelte
@@ -1,10 +1,8 @@
 <script lang="ts">
   import { createEventDispatcher, onDestroy, onMount } from 'svelte'
-
-  import { deleteImageFromWNFS } from '$lib/gallery'
-  import { galleryStore } from '../../../stores'
-  import type { Gallery, Image } from '$lib/gallery'
-  import { fissionServerUrl } from '$lib/app-info'
+  import { fissionServerUrl } from '$lib/app-info';
+  import { galleryStore } from '../../stores'
+  import { deleteImageFromWNFS, type Gallery, type Image } from '../../lib/gallery'
 
   export let image: Image
   export let isModalOpen: boolean = false
@@ -119,7 +117,7 @@
         <div class="relative">
           {#if showPreviousArrow}
             <button
-              class="absolute top-1/2 -left-[25px] -translate-y-1/2 inline-block text-center text-[40px]"
+              class="absolute top-1/2 -left-[21px] -translate-y-1/2 inline-block text-center text-[40px]"
               on:click={() => handleNextOrPrevImage('prev')}
             >
               &#8249;
@@ -132,7 +130,7 @@
           />
           {#if showNextArrow}
             <button
-              class="absolute top-1/2 -right-[25px] -translate-y-1/2 inline-block text-center text-[40px]"
+              class="absolute top-1/2 -right-[21px] -translate-y-1/2 inline-block text-center text-[40px]"
               on:click={() => handleNextOrPrevImage('next')}
             >
               &#8250;

--- a/src/routes/gallery/components/upload/Dropzone.svelte
+++ b/src/routes/gallery/components/upload/Dropzone.svelte
@@ -1,5 +1,8 @@
 <script lang="ts">
-  import { getImagesFromWNFS, uploadImageToWNFS } from '../../lib/gallery'
+  import {
+    getImagesFromWNFS,
+    uploadImageToWNFS
+  } from '$routes/gallery/lib/gallery'
   import { addNotification } from '$lib/notifications'
 
   /**

--- a/src/routes/gallery/components/upload/Dropzone.svelte
+++ b/src/routes/gallery/components/upload/Dropzone.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
+  import { getImagesFromWNFS, uploadImageToWNFS } from '../../lib/gallery'
   import { addNotification } from '$lib/notifications'
-  import { getImagesFromWNFS, uploadImageToWNFS } from '$lib/gallery'
 
   /**
    * Detect when a user drags a file in or out of the dropzone to change the styles
@@ -19,6 +19,8 @@
 
     const files = Array.from(event.dataTransfer.items)
 
+    console.log(`${files.length} file${files.length > 1 ? 's' : ''} dropped`)
+
     // Iterate over the dropped files and upload them to WNFS
     await Promise.all(
       files.map(async (item, index) => {
@@ -28,7 +30,9 @@
           // If the dropped files aren't images, we don't want them!
           if (!file.type.match('image/*')) {
             addNotification('Please upload images only', 'error')
+            console.error('Please upload images only')
           } else {
+            console.log(`file[${index + 1}].name = ${file.name}`)
             await uploadImageToWNFS(file)
           }
         }

--- a/src/routes/gallery/components/upload/Dropzone.svelte
+++ b/src/routes/gallery/components/upload/Dropzone.svelte
@@ -19,8 +19,6 @@
 
     const files = Array.from(event.dataTransfer.items)
 
-    console.log(`${files.length} file${files.length > 1 ? 's' : ''} dropped`)
-
     // Iterate over the dropped files and upload them to WNFS
     await Promise.all(
       files.map(async (item, index) => {
@@ -32,7 +30,6 @@
             addNotification('Please upload images only', 'error')
             console.error('Please upload images only')
           } else {
-            console.log(`file[${index + 1}].name = ${file.name}`)
             await uploadImageToWNFS(file)
           }
         }

--- a/src/routes/gallery/components/upload/FileUploadCard.svelte
+++ b/src/routes/gallery/components/upload/FileUploadCard.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
-  import { galleryStore } from '../../../stores'
-  import { handleFileInput } from '$lib/gallery'
-  import FileUploadIcon from '$components/icons/FileUploadIcon.svelte'
+  import { galleryStore } from '../../stores'
+  import { handleFileInput } from '../../lib/gallery'
+  import FileUploadIcon from '../icons/FileUploadIcon.svelte'
   import LoadingSpinner from '$components/common/LoadingSpinner.svelte'
 
   // Handle files uploaded directly through the file input

--- a/src/routes/gallery/components/upload/FileUploadCard.svelte
+++ b/src/routes/gallery/components/upload/FileUploadCard.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
-  import { galleryStore } from '../../stores'
-  import { handleFileInput } from '../../lib/gallery'
-  import FileUploadIcon from '../icons/FileUploadIcon.svelte'
+  import { galleryStore } from '$routes/gallery/stores'
+  import { handleFileInput } from '$routes/gallery/lib/gallery'
+  import FileUploadIcon from '$routes/gallery/components/icons/FileUploadIcon.svelte'
   import LoadingSpinner from '$components/common/LoadingSpinner.svelte'
 
   // Handle files uploaded directly through the file input

--- a/src/routes/gallery/lib/gallery.ts
+++ b/src/routes/gallery/lib/gallery.ts
@@ -1,15 +1,12 @@
 import { get as getStore } from 'svelte/store'
 import * as wn from 'webnative'
 import * as uint8arrays from 'uint8arrays'
+import type FileSystem from 'webnative/fs/index'
+import type { PuttableUnixTree, File } from 'webnative/fs/types'
 
 import { filesystemStore } from '../../../stores'
-import { galleryStore } from '../stores'
+import { AREAS, galleryStore } from '../stores'
 import { addNotification } from '$lib/notifications'
-
-export enum AREAS {
-  PUBLIC = 'Public',
-  PRIVATE = 'Private'
-}
 
 export type Image = {
   cid: string
@@ -25,6 +22,12 @@ export type Gallery = {
   privateImages: Image[] | null
   selectedArea: AREAS
   loading: boolean
+}
+
+interface GalleryFile extends PuttableUnixTree, File {
+  header: {
+
+  }
 }
 
 export const GALLERY_DIRS = {
@@ -56,16 +59,17 @@ export const getImagesFromWNFS: () => Promise<void> = async () => {
         const file = await fs.get(
           wn.path.file(...GALLERY_DIRS[selectedArea], `${name}`)
         )
+        console.log('file', file)
 
         // The CID for private files is currently located in `file.header.content`,
         // whereas the CID for public files is located in `file.cid`
         const cid = isPrivate
-          ? (file as any).header.content.toString()
-          : (file as any).cid.toString()
+          ? file.header.content.toString()
+          : file.cid.toString()
 
         // Create a base64 string to use as the image `src`
         const src = `data:image/jpeg;base64, ${uint8arrays.toString(
-          (file as any).content,
+          file.content,
           'base64'
         )}`
 

--- a/src/routes/gallery/lib/gallery.ts
+++ b/src/routes/gallery/lib/gallery.ts
@@ -5,8 +5,8 @@ import type { CID } from 'multiformats/cid'
 import type { PuttableUnixTree, File as WNFile } from 'webnative/fs/types'
 import type { Metadata } from 'webnative/fs/metadata'
 
-import { filesystemStore } from '../../../stores'
-import { AREAS, galleryStore } from '../stores'
+import { filesystemStore } from '$src/stores'
+import { AREAS, galleryStore } from '$routes/gallery/stores'
 import { addNotification } from '$lib/notifications'
 
 export type Image = {

--- a/src/routes/gallery/lib/gallery.ts
+++ b/src/routes/gallery/lib/gallery.ts
@@ -139,7 +139,6 @@ export const uploadImageToWNFS: (
     // Announce the changes to the server
     await fs.publish()
 
-    console.log(`${image.name} image has been published`)
     addNotification(`${image.name} image has been published`, 'success')
   } catch (error) {
     addNotification(error.message, 'error')
@@ -169,7 +168,6 @@ export const deleteImageFromWNFS: (
       // Announce the changes to the server
       await fs.publish()
 
-      console.log(`${name} image has been deleted`)
       addNotification(`${name} image has been deleted`, 'success')
 
       // Refetch images and update galleryStore

--- a/src/routes/gallery/lib/gallery.ts
+++ b/src/routes/gallery/lib/gallery.ts
@@ -67,7 +67,6 @@ export const getImagesFromWNFS: () => Promise<void> = async () => {
         const file = await fs.get(
           wn.path.file(...GALLERY_DIRS[selectedArea], `${name}`)
         )
-        console.log('file', file)
 
         // The CID for private files is currently located in `file.header.content`,
         // whereas the CID for public files is located in `file.cid`
@@ -154,7 +153,7 @@ export const uploadImageToWNFS: (
     addNotification(`${image.name} image has been published`, 'success')
   } catch (error) {
     addNotification(error.message, 'error')
-    console.log(error)
+    console.error(error)
   }
 }
 

--- a/src/routes/gallery/stores.ts
+++ b/src/routes/gallery/stores.ts
@@ -1,7 +1,7 @@
 import { writable } from 'svelte/store'
 import type { Writable } from 'svelte/store'
 
-import type { Gallery } from './lib/gallery'
+import type { Gallery } from '$routes/gallery/lib/gallery'
 
 export enum AREAS {
   PUBLIC = 'Public',

--- a/src/routes/gallery/stores.ts
+++ b/src/routes/gallery/stores.ts
@@ -1,5 +1,6 @@
 import { writable } from 'svelte/store'
 import type { Writable } from 'svelte/store'
+
 import { AREAS } from './lib/gallery'
 import type { Gallery } from './lib/gallery'
 

--- a/src/routes/gallery/stores.ts
+++ b/src/routes/gallery/stores.ts
@@ -1,12 +1,16 @@
 import { writable } from 'svelte/store'
 import type { Writable } from 'svelte/store'
 
-import { AREAS } from './lib/gallery'
 import type { Gallery } from './lib/gallery'
+
+export enum AREAS {
+  PUBLIC = 'Public',
+  PRIVATE = 'Private'
+}
 
 export const galleryStore: Writable<Gallery> = writable({
   loading: true,
   publicImages: [],
   privateImages: [],
-  selectedArea: AREAS.PUBLIC
+  selectedArea: AREAS.PUBLIC,
 })

--- a/src/routes/gallery/stores.ts
+++ b/src/routes/gallery/stores.ts
@@ -1,0 +1,11 @@
+import { writable } from 'svelte/store'
+import type { Writable } from 'svelte/store'
+import { AREAS } from './lib/gallery'
+import type { Gallery } from './lib/gallery'
+
+export const galleryStore: Writable<Gallery> = writable({
+  loading: true,
+  publicImages: [],
+  privateImages: [],
+  selectedArea: AREAS.PUBLIC
+})

--- a/src/stores.ts
+++ b/src/stores.ts
@@ -3,8 +3,6 @@ import type { Writable } from 'svelte/store'
 import type FileSystem from 'webnative/fs/index'
 
 import { loadTheme } from '$lib/theme'
-import { AREAS } from '$lib/gallery'
-import type { Gallery } from '$lib/gallery'
 import type { Notification } from '$lib/notifications'
 import type { Session } from '$lib/session'
 import type { Theme } from '$lib/theme'
@@ -19,12 +17,5 @@ export const sessionStore: Writable<Session> = writable({
 })
 
 export const filesystemStore: Writable<FileSystem | null> = writable(null)
-
-export const galleryStore: Writable<Gallery> = writable({
-  loading: true,
-  publicImages: [],
-  privateImages: [],
-  selectedArea: AREAS.PUBLIC,
-})
 
 export const notificationStore: Writable<Notification[]> = writable([])

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -25,6 +25,8 @@
     "paths": {
       "$components/*": ["src/components/*"],
       "$lib/*": ["src/lib/*"],
+      "$routes/*": ["src/routes/*"],
+      "$src/*": ["src/*"],
       "$static/*": ["static/*"]
     }
   },

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -7,6 +7,8 @@ const config = {
   resolve: {
     alias: {
       $components: resolve('./src/components'),
+      $routes: resolve('./src/routes'),
+      $src: resolve('./src'),
       $static: resolve('./static')
     }
   }


### PR DESCRIPTION
# Description

Consolidating the gallery code using the same DDD approach I used in the `walletauth` repo. All the gallery code lives in `routes/gallery` now, with the exception of the filesystem initialization in `auth/account.ts`(which i think we can probably even remove because the filesystem is automatically created for the user when they push to the gallery 🤷🏼). This should make it easier to remove all the gallery code when someone copies the template or when we make a generator.

## Link to issue

N/A

## Type of change

- [x] Refactor (non-breaking change that updates existing functionality)

## Screenshots/Screencaps

<img width="1199" alt="image" src="https://user-images.githubusercontent.com/1179291/192074114-77dbe3cb-0aea-455d-af71-304f703aa929.png">

